### PR TITLE
[codex] Move package to Capgo npm scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# capacitor-standard-version
+# @capgo/capacitor-standard-version
   <a href="https://capgo.app/"><img src='https://raw.githubusercontent.com/Cap-go/capgo/main/assets/capgo_banner.png' alt='Capgo - Instant updates for capacitor'/></a>
 <div align="center">
   <h2><a href="https://capgo.app/?ref=plugin"> ➡️ Get Instant updates for your App with Capgo</a></h2>
@@ -13,13 +13,13 @@ All config from .versionrc, .versionrc.json or .versionrc.js are supported
 
 ## Install
 
-`npm i capacitor-standard-version`
+`bun add -D @capgo/capacitor-standard-version`
 
 ## Usage
 
-Run `npx capacitor-standard-version` for update main version or `npx capacitor-standard-version --prerelease alpha` for alpha release for dev branch.
+Run `bunx capacitor-standard-version` for update main version or `bunx capacitor-standard-version --prerelease alpha` for alpha release for dev branch.
 
-Exemple of Github action to do it on every commit in `main` and `development`
+Example of GitHub Action to do it on every commit in `main` and `development`
 
 ```yml
 on:
@@ -39,16 +39,20 @@ jobs:
         with:
           fetch-depth: 0
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
       - name: Git config
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
       - name: Create bump and changelog
         if: github.ref == 'refs/heads/main'
-        run: npx capacitor-standard-version
+        run: bunx capacitor-standard-version
       - name: Create bump and changelog
         if: github.ref != 'refs/heads/main'
-        run: npx capacitor-standard-version --prerelease alpha
+        run: bunx capacitor-standard-version --prerelease alpha
       - name: Push to origin
         run: |
           CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 0,
   "workspaces": {
     "": {
-      "name": "capacitor-standard-version",
+      "name": "@capgo/capacitor-standard-version",
       "dependencies": {
         "commit-and-tag-version": "^12.6.1",
         "merge-deep": "^3.0.3",
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@antfu/eslint-config": "^6.7.3",
         "@types/bun": "^1.3.5",
-        "@types/node": "^25.0.3",
+        "@types/node": "^24.10.4",
         "typescript": "^5.9.3",
       },
     },
@@ -95,7 +95,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
+    "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
@@ -888,6 +888,8 @@
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "bun-types/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "capacitor-standard-version",
+  "name": "@capgo/capacitor-standard-version",
   "version": "1.3.30",
   "description": "Default standard-version config for capacitor app",
   "author": "Martin Donadieu <martindonadieu@gmail.com>",
@@ -19,6 +19,9 @@
     "cli"
   ],
   "main": "dist/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "capacitor-standard-version": "dist/index.js"
   },


### PR DESCRIPTION
## What changed
- move the package from the unscoped `capacitor-standard-version` name to `@capgo/capacitor-standard-version`
- add `publishConfig.access = public` so scoped publishes target the public Capgo npm org correctly
- update the README install and usage examples to the new scoped package name and Bun-first commands
- refresh the GitHub Action example to install Bun before running the CLI

## Why
The repository already lives under Capgo on GitHub, but the npm package was still published under an unscoped name. This aligns the package with the Capgo npm organization and updates the docs to match how Capgo repos are maintained.

## Impact
Consumers will install the package from the Capgo npm scope while continuing to invoke the same `capacitor-standard-version` binary.

## Validation
- `bun run build`
- `bun run test`
- `bun run lint .`
