### PR TITLE
fix: handle first release in publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,49 @@ jobs:
       - name: Build
         id: build_code
         run: bun run build
+      - name: Detect previous tag
+        id: previous_tag
+        shell: bash
+        run: |
+          current_tag="${GITHUB_REF##*/}"
+          echo "current=$current_tag" >> "$GITHUB_OUTPUT"
+          if previous_tag=$(git describe --tags --abbrev=0 "${current_tag}^" 2>/dev/null); then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "value=$previous_tag" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Generate AI changelog
         id: changelog
+        if: ${{ steps.previous_tag.outputs.found == 'true' }}
         uses: mistricky/ccc@v0.2.6
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model: claude-sonnet-4-5-20250929
+      - name: Prepare release notes
+        id: release_notes
+        shell: bash
+        env:
+          CURRENT_TAG: ${{ steps.previous_tag.outputs.current }}
+          PREVIOUS_TAG: ${{ steps.previous_tag.outputs.value }}
+          CHANGELOG_TEXT: ${{ steps.changelog.outputs.result }}
+        run: |
+          if [[ "${{ steps.previous_tag.outputs.found }}" == "true" ]]; then
+            {
+              printf '## 🆕 Changelog\n\n'
+              printf '%s\n\n' "$CHANGELOG_TEXT"
+              printf '%s\n\n' '---'
+              printf '🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/%s...%s\n' "$PREVIOUS_TAG" "$CURRENT_TAG"
+            } > release-notes.md
+          else
+            {
+              printf '## 🆕 Changelog\n\n'
+              printf 'Initial release.\n\n'
+              printf '%s\n\n' '---'
+              printf '🔖 **Tag**: %s\n' "$CURRENT_TAG"
+            } > release-notes.md
+          fi
       - name: Setup Node.js for npm publish
         uses: actions/setup-node@v6
         with:
@@ -55,14 +91,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          body: |
-            ## 🆕 Changelog
-
-            ${{ steps.changelog.outputs.result }}
-
-            ---
-
-            🔗 **Full Changelog**: https://github.com/${{ github.repository }}/compare/${{ steps.changelog.outputs.from_tag }}...${{ steps.changelog.outputs.to_tag }}
+          body_path: release-notes.md
           make_latest: true
           token: '${{ secrets.PERSONAL_ACCESS_TOKEN }}'
           prerelease: ${{ contains(github.ref, '-alpha.') }}

--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -14,6 +14,6 @@ jobs:
         uses: SethCohen/github-releases-to-discord@v1
         with:
           webhook_url: ${{ secrets.WEBHOOK_DISCORD_RELEASE_URL }}
-          color: "2105893"
-          footer_title: "Release @${{ github.repository }}"
+          color: '2105893'
+          footer_title: 'Release @${{ github.repository }}'
           reduce_headings: true


### PR DESCRIPTION
## Summary\n- guard the AI changelog step when a tag has no previous tag\n- generate fallback release notes for an initial release\n- switch GitHub release creation to use a prepared release notes file\n\n## Context\nThe proximity plugin release workflow failed on its first tagged release because  has no previous tag to resolve. This ports the same fix into the template so new plugins inherit it by default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process automation, including enhanced release notes generation and output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->